### PR TITLE
Bump version typescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+# **4.10.1 - (2025-08-24)**
+
+## **Updates**
+
+- Bump version `typescript@5.8.3` ([3c5a444](https://github.com/telegramsjs/Telegramsjs/commit/3c5a444efbe2dfb88f357d5ff5f9854a64553fcd))
+
+## **Typings**
+
+- **WebhookClient:** return type `close` methods ([53e4c19](https://github.com/telegramsjs/Telegramsjs/commit/53e4c19605cd86c84ac86698359579cc88ec0f15))
+
+---
+
 # **4.10.0 - (2025-08-24)**
 
 ## **Updates**
@@ -19,7 +31,7 @@
 
 - **WorkerClient:** corrent `ChatDelete` event name ([86a2433](https://github.com/telegramsjs/Telegramsjs/commit/86a2433d045cfd4b2cce7aa6449319f7e1e8f50b))
 - **WorkerClient:** type in the name `worket` ([5ff4122](https://github.com/telegramsjs/Telegramsjs/commit/5ff4122d6c98ed5b5e3d2385916276aa79f3f7b1))
-- **WebhookClient:** async close now waits for server shutdown ([e2605d8](https://github.com/telegramsjs/Telegramsjs/commit/e2605d8717a3d039b818d308d42a2f642dbaf581))
+- **WebhookClient:** async `close` now waits for server shutdown ([e2605d8](https://github.com/telegramsjs/Telegramsjs/commit/e2605d8717a3d039b818d308d42a2f642dbaf581))
 
 
 ## **Typings**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "telegramsjs",
   "description": "A powerful library for interacting with the Telegram Bot API",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "main": "./dist/src/index.js",
   "types": "./typings/index.d.ts",
   "scripts": {
@@ -57,7 +57,7 @@
     "@types/node": "^18.19.61",
     "@types/node-fetch": "^2.6.11",
     "@types/safe-compare": "^1.1.2",
-    "typescript": "5.7.3"
+    "typescript": "5.8.3"
   },
   "dependencies": {
     "@telegram.ts/collection": "^1.1.0",

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -10766,7 +10766,7 @@ export declare class WebhookClient {
    * Closes the webhook server.
    * @returns The closed state of the webhook client.
    */
-  close(): boolean;
+  close(): Promise<boolean>;
 }
 
 /**
@@ -13157,6 +13157,6 @@ export declare class StarTransactions {
   [Symbol.iterator](): IterableIterator<StarTransaction>;
 }
 
-export declare const version: "4.10.0";
+export declare const version: "4.10.1";
 
 export * from "./telegram/index";


### PR DESCRIPTION
# **4.10.1 - (2025-08-24)**

## **Updates**

- Bump version `typescript@5.8.3` ([3c5a444](https://github.com/telegramsjs/Telegramsjs/commit/3c5a444efbe2dfb88f357d5ff5f9854a64553fcd))

## **Typings**

- **WebhookClient:** return type `close` methods ([53e4c19](https://github.com/telegramsjs/Telegramsjs/commit/53e4c19605cd86c84ac86698359579cc88ec0f15))